### PR TITLE
feat: Invalidate user queries after activating free rent

### DIFF
--- a/src/components/features/minSide/leie/freeRent/FreeRent.tsx
+++ b/src/components/features/minSide/leie/freeRent/FreeRent.tsx
@@ -22,6 +22,7 @@ const FreeRent = () => {
   const { mutate: updateUser } = useMutation({
     mutationFn: activeUserProfile,
     onSuccess: () => {
+      queryClient.invalidateQueries(UserQueries.me(jwt));
       toast.success("Gratis leie aktivert!");
     },
   });


### PR DESCRIPTION
In the FreeRent component, invalidate the user queries after successfully activating free rent. This ensures that the user's data is updated with the latest changes. Additionally, display a success toast message to notify the user that free rent has been activated.