### PR TITLE
feat: Add product count display on produkter page

### DIFF
--- a/src/app/min-side/selge/produkter/page.tsx
+++ b/src/app/min-side/selge/produkter/page.tsx
@@ -31,6 +31,13 @@ const Produkter = () => {
           <PlusCircle size={36} color="green" />
         </Link>
       </div>
+      <div className="flex justify-center gap-6">
+        <p className="pb-4 text-center italic">
+          <b className="text-lg text-brand-500">
+            {products.length} {products.length === 1 ? "produkt" : "produkter"}
+          </b>
+        </p>
+      </div>
       <ProductTable products={products} />
     </div>
   );


### PR DESCRIPTION
Display the number of products on the produkter page using a dynamic text that updates based on the number of products. This provides users with a clear indication of how many products are currently listed.